### PR TITLE
[New Feature] Added ability to download current page to local file system

### DIFF
--- a/languages/ca.json
+++ b/languages/ca.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Afegeix marcador",
 		"removeBookmark": "Eliminar marcador",
 		"emptyBookmarks": "No hi ha cap marcador",
-		"currentReading": "Lectura actual"
+		"currentReading": "Lectura actual",
+		"saveImage": "Guardar imatge"
 	},
 	"settings": {
 		"general": "General",

--- a/languages/cs.json
+++ b/languages/cs.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Přidat záložku",
 		"removeBookmark": "Odstranit záložku",
 		"emptyBookmarks": "Žádné záložky",
-		"currentReading": "Rozečtené"
+		"currentReading": "Rozečtené",
+		"saveImage": "Uložit obrázek"
 	},
 	"settings": {
 		"general": "",

--- a/languages/de.json
+++ b/languages/de.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Lesezeichen hinzufügen",
 		"removeBookmark": "Lesezeichen entfernen",
 		"emptyBookmarks": "Keine Lesezeichen",
-		"currentReading": "Zurzeit lesend"
+		"currentReading": "Zurzeit lesend",
+		"saveImage": "Bild speichern"
 	},
 	"settings": {
 		"general": "",

--- a/languages/en.json
+++ b/languages/en.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Add bookmark",
 		"removeBookmark": "Remove bookmark",
 		"emptyBookmarks": "No bookmarks",
-		"currentReading": "Current reading"
+		"currentReading": "Current reading",
+		"saveImage": "Save image"
 	},
 	"settings": {
 		"general": "General",

--- a/languages/es.json
+++ b/languages/es.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Añadir marcador",
 		"removeBookmark": "Eliminar marcador",
 		"emptyBookmarks": "No hay ningún marcador",
-		"currentReading": "Lectura actual"
+		"currentReading": "Lectura actual",
+		"saveImage": "Guardar imagen"
 	},
 	"settings": {
 		"general": "General",

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Ajouter signet",
 		"removeBookmark": "Retirer signet",
 		"emptyBookmarks": "Aucun signet",
-		"currentReading": "Lecture en cours"
+		"currentReading": "Lecture en cours",
+		"saveImage": "Enregistrer l'image"
 	},
 	"settings": {
 		"general": "",

--- a/languages/hu.json
+++ b/languages/hu.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Könyvjelző hozzáadása",
 		"removeBookmark": "Könyvjelző törlése",
 		"emptyBookmarks": "Nincsenek könyvjelzők",
-		"currentReading": "Most olvasott"
+		"currentReading": "Most olvasott",
+		"saveImage": "Kép mentése"
 	},
 	"settings": {
 		"general": "",

--- a/languages/it.json
+++ b/languages/it.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Aggiungi segnalibro",
 		"removeBookmark": "Rimuovi segnalibro",
 		"emptyBookmarks": "Nessun segnalibro",
-		"currentReading": "Lettura attuale"
+		"currentReading": "Lettura attuale",
+		"saveImage": "Salva immagine"
 	},
 	"settings": {
 		"general": "",

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -190,7 +190,8 @@
 		"addBookmark": "しおりの追加",
 		"removeBookmark": "しおりの削除",
 		"emptyBookmarks": "しおりがありません",
-		"currentReading": "現在読んでいる位置"
+		"currentReading": "現在読んでいる位置",
+		"saveImage": "画像を保存"
 	},
 	"settings": {
 		"general": "",

--- a/languages/ko.json
+++ b/languages/ko.json
@@ -190,7 +190,8 @@
 		"addBookmark": "",
 		"removeBookmark": "",
 		"emptyBookmarks": "",
-		"currentReading": ""
+		"currentReading": "",
+		"saveImage": "이미지를 저장"
 	},
 	"settings": {
 		"general": "일반",

--- a/languages/pt-br.json
+++ b/languages/pt-br.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Adicionar a favorito",
 		"removeBookmark": "Remover favorito",
 		"emptyBookmarks": "Sem favoritos",
-		"currentReading": "Leitura atual"
+		"currentReading": "Leitura atual",
+		"saveImage": "Salvar imagem"
 	},
 	"settings": {
 		"general": "",

--- a/languages/ru.json
+++ b/languages/ru.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Добавить закладку",
 		"removeBookmark": "Удалить закладку",
 		"emptyBookmarks": "Нет закладок",
-		"currentReading": "Текущее чтение"
+		"currentReading": "Текущее чтение",
+		"saveImage": "Сохранить изображение"
 	},
 	"settings": {
 		"general": "",

--- a/languages/sv.json
+++ b/languages/sv.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Lägg till bokmärke",
 		"removeBookmark": "Ta bort bokmärke",
 		"emptyBookmarks": "Inga bokmärken",
-		"currentReading": "Aktuell läsning"
+		"currentReading": "Aktuell läsning",
+		"saveImage": "Spara bild"
 	},
 	"settings": {
 		"general": "Allmänt",

--- a/languages/th.json
+++ b/languages/th.json
@@ -190,7 +190,8 @@
 		"addBookmark": "เพิ่มบุ๊คมาร์ก",
 		"removeBookmark": "นำบุ๊คมาร์กออก",
 		"emptyBookmarks": "ไม่มีบุ๊คมาร์ก",
-		"currentReading": "กำลังอ่านอยู่"
+		"currentReading": "กำลังอ่านอยู่",
+		"saveImage": "บันทึกภาพ"
 	},
 	"settings": {
 		"general": "ทั่วไป",

--- a/languages/vi.json
+++ b/languages/vi.json
@@ -190,7 +190,8 @@
 		"addBookmark": "Thêm dấu trang",
 		"removeBookmark": "Xóa dấu trang",
 		"emptyBookmarks": "Không có dấu trang",
-		"currentReading": "Hiện đang đọc"
+		"currentReading": "Hiện đang đọc",
+		"saveImage": "Lưu hình ảnh"
 	},
 	"settings": {
 		"general": "Chung",

--- a/languages/zh-hans.json
+++ b/languages/zh-hans.json
@@ -190,7 +190,8 @@
 		"addBookmark": "添加书签",
 		"removeBookmark": "移除书签",
 		"emptyBookmarks": "暂无书签",
-		"currentReading": "当前阅读"
+		"currentReading": "当前阅读",
+		"saveImage": "保存图片"
 	},
 	"settings": {
 		"general": "常规设置",

--- a/languages/zh-hant.json
+++ b/languages/zh-hant.json
@@ -190,7 +190,8 @@
 		"addBookmark": "新增書籤",
 		"removeBookmark": "移除書籤",
 		"emptyBookmarks": "暫無書籤",
-		"currentReading": "正在閱讀"
+		"currentReading": "正在閱讀",
+		"saveImage": "保存图片"
 	},
 	"settings": {
 		"general": "",

--- a/scripts/reading.js
+++ b/scripts/reading.js
@@ -5,6 +5,45 @@ const render = require(p.join(appDir, 'scripts/reading/render.js')),
 
 var images = {}, imagesData = {}, imagesDataClip = {}, imagesPath = {}, imagesNum = 0, contentNum = 0, imagesNumLoad = 0, currentIndex = 1, imagesPosition = {}, imagesFullPosition = {}, prevImagesFullPosition = {}, foldersPosition = {}, indexNum = 0, imagesDistribution = [], currentPageXY = {x: 0, y: 0}, currentMousePosition = {pageX: 0, pageY: 0};
 
+//Remove characters that are invalid in filesystem naming conventions
+function removeInvalidCharacters(unmodifiedTitle) {
+	if (unmodifiedTitle === null || unmodifiedTitle === undefined) return "";
+	let invalidCharactersToRemove = /[<>:"\/\\|?*\x00-\x1F]|amp;/g;
+	return unmodifiedTitle.toString().replace(invalidCharactersToRemove, '');
+}
+
+//Creates a string that will be used as the default filename when saving an image
+function createFileNameForImage(imageExtension) {
+	let seriesTitleInnerHTML = document.getElementsByClassName("bar-title-a")[0].innerHTML;
+	let documentTitle = document.title;
+	let seriesTitle = seriesTitleInnerHTML ? removeInvalidCharacters(seriesTitleInnerHTML) : "";
+	let issueTitle = documentTitle? removeInvalidCharacters(documentTitle) : "";
+	let pageNumber = currentIndex ? "Page" + currentIndex : "";
+	return seriesTitle + "_" +
+		issueTitle + "_" +
+		pageNumber + "." +
+		imageExtension;
+}
+
+//Saves current page to filesystem
+function saveImage() {
+	let imageToSave = images[currentIndex].src;
+	let imageExtension = imageToSave.split('.').pop();
+	if (imageToSave && imageExtension) {
+		fetch(imageToSave)
+			.then(response => response.blob())
+			.then(blob => {
+				let link = document.createElement('a');
+				link.href = window.URL.createObjectURL(blob);
+				link.download = createFileNameForImage(imageExtension);
+				link.click();
+			})
+			.catch(error => console.error('Error saving image to local fileystem:', error));
+	} else {
+		console.error("Could not retrieve the current image");
+	}
+}
+
 //Calculates whether to add a blank image (If the reading is in double page and do not apply to the horizontals)
 function blankPage(index)
 {
@@ -5272,6 +5311,7 @@ module.exports = {
 	saveReadingProgressA: function(){return saveReadingProgressA},
 	setFromSkip: setFromSkip,
 	createAndDeleteBookmark: createAndDeleteBookmark,
+	saveImage: saveImage,
 	deleteBookmark: deleteBookmark,
 	currentIndex: function(){return currentIndex},
 	currentPageVisibility: function(){return currentPageVisibility},

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -257,6 +257,12 @@ function loadShortcuts()
 						return true;
 					},
 				},
+				saveImage: {
+					name: language.reading.saveImage,
+					function: function () {
+						reading.saveImage();
+					}
+				},
 				zoomIn: {
 					name: language.menu.view.zoomIn,
 					function: function(){

--- a/templates/reading.header.html
+++ b/templates/reading.header.html
@@ -28,6 +28,7 @@
 		<div class="bar-buttons-separator"></div>
 		<div class="material-icon button button1 button-tracking-sites hover-text" hover-text="{{language.reading.tracking.main}}" onclick="reading.loadTrackigSites();events.activeMenu('#tracking-sites', '.bar-right-buttons .button-tracking-sites', 'right');">sync</div>
 		<div class="bar-buttons-separator"></div>
+		<div class="material-icon button button2 download hover-text" hover-text="{{language.reading.saveImage}}" onclick="reading.saveImage();">download</div>
 		<div class="material-icon button button1 button-collections-bookmark hover-text" hover-text="{{language.reading.viewBookmarks}}" onclick="reading.loadBookmarks();events.activeMenu('#collections-bookmark', '.bar-right-buttons .button-collections-bookmark', 'right');">collections_bookmark</div>
 		<div class="material-icon button button2 button-bookmark hover-text" hover-text="{{language.reading.addBookmark}}" onclick="reading.createAndDeleteBookmark();">bookmark_border</div>
 		<div class="bar-buttons-separator"></div>


### PR DESCRIPTION
# Links
[Feature request](https://github.com/ollm/OpenComic/issues/218)
[Material Icon for download button](https://fonts.google.com/icons?selected=Material+Symbols+Outlined:download:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=download&icon.size=24&icon.color=%23e8eaed)

# Description

Adds a toolbar button for readers to save the current file to their filesystem. The code takes the current index, retrieves the image, and automatically creates a filename that contains the issue title. 

# Changelog
- Added translations for new string 'Save Image' using Google Translations
- Added download button to toolbar
- Added logic that saves the current image to filesystem.

# Testing Instructions

1. Build project
```
npm install
npm run rebuild
npm start
```
2. Open file to read

3. Next to 'View Bookmarks' there is a new icon called 'Save image'. Click it and it should open up file explorer

4. Save image using default file format:

[Title of Book Series]_[Title of issue]_Page[CurrentPage].[FileExtension]

# Demo

Dark mode

![light_mode_save_button](https://github.com/ollm/OpenComic/assets/9469720/5a65313f-d1c3-407d-9256-6bf09faf7cca)

Light mode

![dark_mode_save_button](https://github.com/ollm/OpenComic/assets/9469720/b3e6124e-6b5d-4374-9260-de1f69dbd870)
